### PR TITLE
Use the correct 'roundCount' parameter for generate challenge

### DIFF
--- a/geoguessr_async/geoguessr.py
+++ b/geoguessr_async/geoguessr.py
@@ -167,7 +167,7 @@ class Geoguessr:
         """
         challengeToken = challengeUrl.split("/")[-1] if "/" in challengeUrl else challengeUrl
 
-        link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26&minRounds=5"
+        link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26"
         r = await self.session.get(link)
 
         if r.status != 200:  # Map not already played
@@ -180,7 +180,7 @@ class Geoguessr:
         paginationToken = js["paginationToken"]
 
         while paginationToken is not None:
-            link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26&minRounds=5&paginationToken={parse.quote(paginationToken)}"
+            link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26&paginationToken={parse.quote(paginationToken)}"
             async with self.session.get(link) as r:
                 js = await r.json()
 

--- a/geoguessr_async/geoguessr.py
+++ b/geoguessr_async/geoguessr.py
@@ -282,7 +282,7 @@ class Geoguessr:
             "forbidRotating": not pan,
             "forbidZooming": not zoom,
             "timeLimit": timeLimit,
-            "rounds": numRounds,
+            "roundCount": numRounds,
         }
 
         async with self.session.post(url, json=data) as response:

--- a/geoguessr_async/geoguessr.py
+++ b/geoguessr_async/geoguessr.py
@@ -167,7 +167,7 @@ class Geoguessr:
         """
         challengeToken = challengeUrl.split("/")[-1] if "/" in challengeUrl else challengeUrl
 
-        link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26"
+        link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26&minRounds=1"
         r = await self.session.get(link)
 
         if r.status != 200:  # Map not already played
@@ -180,7 +180,7 @@ class Geoguessr:
         paginationToken = js["paginationToken"]
 
         while paginationToken is not None:
-            link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26&paginationToken={parse.quote(paginationToken)}"
+            link = f"https://geoguessr.com/api/v3/results/highscores/{challengeToken}?friends=false&limit=26&minRounds=1&paginationToken={parse.quote(paginationToken)}"
             async with self.session.get(link) as r:
                 js = await r.json()
 


### PR DESCRIPTION
After testing with newly published version 1.1.0, I discovered the challenges were still being generated with 5 rounds even when passing different values. Have tested this fix locally